### PR TITLE
fix: correctly detect if pull request for a release branch is open

### DIFF
--- a/lib/pull-request.js
+++ b/lib/pull-request.js
@@ -13,7 +13,7 @@ async function createOrUpdatePr(env, commit_msg, body) {
   const { data: pr } = await env.octokit.pulls.list({
     state: 'open',
     base: env.config.base_branch,
-    head: `${env.config.release_branch}`,
+    head: `${env.repo_context.owner}:${env.config.release_branch}`,
     ...env.repo_context
   })
 

--- a/test/pull-request.test.js
+++ b/test/pull-request.test.js
@@ -24,13 +24,17 @@ describe('pull-request', () => {
     }
     nock('https://api.github.com')
       .get('/repos/patrickjahns/chlgr/pulls')
-      .query({ state: 'open', base: 'master', head: 'release/next' })
+      .query({
+        state: 'open',
+        base: 'master',
+        head: 'patrickjahns:release/next'
+      })
       .reply(200, [])
     nock('https://api.github.com')
       .post('/repos/patrickjahns/chlgr/pulls', body => {
         expect(body).toMatchObject({
-          body: `test`,
-          title: `test`,
+          body: 'test',
+          title: 'test',
           head: 'release/next',
           base: 'master',
           maintainer_can_modify: true
@@ -56,7 +60,11 @@ describe('pull-request', () => {
     }
     nock('https://api.github.com')
       .get('/repos/patrickjahns/chlgr/pulls')
-      .query({ state: 'open', base: 'master', head: 'release/next' })
+      .query({
+        state: 'open',
+        base: 'master',
+        head: 'patrickjahns:release/next'
+      })
       .reply(200, require('./fixtures/open_pull_request'))
     nock('https://api.github.com')
       .patch('/repos/patrickjahns/chlgr/pulls/5', body => {


### PR DESCRIPTION
When using `head` in the pull request api https://developer.github.com/v3/pulls/#list-pull requests, it is required to specify a head user/organization. Otherwise the result
will contain also other branches and the action falsely detects open pull requests